### PR TITLE
Support Django >= 1.9

### DIFF
--- a/panopto_client/__init__.py
+++ b/panopto_client/__init__.py
@@ -2,7 +2,7 @@
 Base module to support exposing Panopto SOAP Service methods
 """
 from django.conf import settings
-from django.utils.log import getLogger
+from logging import getLogger
 from suds.client import Client
 from suds.xsd.schema import Schema
 from suds import WebFault

--- a/panopto_client/mock/__init__.py
+++ b/panopto_client/mock/__init__.py
@@ -2,8 +2,13 @@
 Panopto API mock data class
 """
 from django.conf import settings
-from django.utils.importlib import import_module
-from django.utils.log import getLogger
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
+from logging import getLogger
 from hashlib import md5
 import sys
 import os


### PR DESCRIPTION
django.utils.log.getLogger does not appear to have been part of the public API, and no longer works.
django.utils.importlib was deprecated and has been removed.